### PR TITLE
Select full link automatically when sharing

### DIFF
--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -460,6 +460,7 @@ const toggleShareSettings = function(){
   let paramString = `${baseUrl}?level=${level}&blocks=${blockString}`
   shareModal.setAttribute("value",paramString);
   MicroModal.show('share-modal');
+  shareModal.select();
 }
 
 const copyLink = function(){


### PR DESCRIPTION
Previously, when the sharing link was made longer (by adding blocks
for example), copying the new longer link with ctrl-c would not
update properly. This change fixes that bug so that the entire
sharing link is selected automatically when the link modal is opened.