### PR TITLE
Fix assorted bugs from Custom Rhythm migration

### DIFF
--- a/assets/javascripts/components/notationPanel.js
+++ b/assets/javascripts/components/notationPanel.js
@@ -127,7 +127,8 @@ function notationPanel(options){
       } else {
         scaleFactor = 0.75;
         this.stave.setY(0);
-        let staveWidth = this.blockEl.clientWidth * (0.50 + (this.notes.length*0.1));
+        const adjustedStaveWidth = this.blockEl.clientWidth * (0.50 + (this.notes.length*0.1))
+        let staveWidth = Math.min(adjustedStaveWidth, this.blockEl.clientWidth);
         let staveX = (this.blockEl.clientWidth*0.5)-staveWidth*0.5;
         this.stave.setX(staveX);
         this.stave.setWidth(staveWidth);

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -4,7 +4,7 @@ const VF = Vex.Flow;
 let Levels = [];
 let Blocks = [];
 let DupBlocks = [];
-let FillerBlocks =[];
+let FillerBlocks = buildFallbackBlocks(fillerBlockData);
 
 //Initializing MicroModal for introduction flow;
 MicroModal.init();

--- a/assets/javascripts/main.js
+++ b/assets/javascripts/main.js
@@ -343,7 +343,7 @@ const toggleRests = function(){
 const toggleTuplets = function(){
   tupletsOn = !tupletsOn;
   if(tupletsOn){ restsOn = false };
-  let newLevel = getLevel(tupletsOn ? "5" : "1")
+  let newLevel = getLevel(tupletsOn ? CompoundLevels[0].name: SimpleLevels[0].name)
   changeLevel(newLevel); //change level to current level to force a re-render
   changeDifficulty(restsOn ? "a-r" : "a");
   let button = document.getElementById("tuplets-toggle-button")

--- a/assets/javascripts/services/customRhythmService.js
+++ b/assets/javascripts/services/customRhythmService.js
@@ -16,7 +16,7 @@ async function getCustomRhythms(){
         })
         .catch((e)=>{
             console.warn(e);
-            console.log("Cannot load custom rhythms. Building fallbacks...")
+            console.info("Cannot load custom rhythms. Building fallbacks...")
             buildFallbackRhythms();
         })
     // httpGetAsync(levelsUrl, buildCustomLevels);
@@ -109,7 +109,7 @@ function getEntries(parsedResponse){
 
 function buildLevelFromEntry(entry){
     let levelAttrs = {
-        "name": entry.gsx$name.$t,
+        "name": entry.gsx$name.$t.trim(),
         "description": entry.gsx$description.$t,
         "measureBeats": parseInt(entry.gsx$measurebeats.$t),
         "quaver": parseInt(entry.gsx$quaver.$t),
@@ -123,9 +123,9 @@ function buildLevelFromEntry(entry){
 
 function buildBlockFromEntry(entry){
     let blockAttrs = {
-        "level": entry.gsx$level.$t,
+        "level": entry.gsx$level.$t.trim(),
         "rhythmSet": entry.gsx$rhythmset.$t.toLowerCase().split(","),
-        "noteString": entry.gsx$notestring.$t,
+        "noteString": entry.gsx$notestring.$t.trim(),
     }
     const newBlock = new rhythmBlockElement(blockAttrs);
     return newBlock;

--- a/assets/stylesheets/main-styles.css
+++ b/assets/stylesheets/main-styles.css
@@ -76,6 +76,7 @@ a.active{
   line-height: normal;
   display: inline-block;
   vertical-align: middle;
+  cursor: default;
 }
 
 .level-button img {


### PR DESCRIPTION
Fixes the following issues:

- Eliminates a bug that prevented proper scaling of blocks because of how the centering position was calculated. The width of the staff now defaults to the smaller of two values: the width needed to keep a small block centered or the maximum width of the block panel.
- Allows the Tuplet toggle button to default to the first compound level that is present instead of hard-coded level 5.
- Eliminates a bug caused by leading/trailing whitespace on characters from the Google sheet in Level and Block names.
- Corrects the incomplete block bug by reinstating the FillerBlock creation.