### PR TITLE
Add sixteenth note deadcounts

### DIFF
--- a/assets/javascripts/components/passageGenerator.js
+++ b/assets/javascripts/components/passageGenerator.js
@@ -416,9 +416,9 @@ const passageGenerator = function(blocks){
     };   
 
     this.getCountText = function(tickRemainder, beatNumber, ticksPerBeat){
-        if(tickRemainder < BEAT_TICKS_ERROR_RANGE){
+        if(tickRemainder <= BEAT_TICKS_ERROR_RANGE){
             if(activeLevel.tuplet){
-                if(activeLevel.deadEighthsOn){
+                if(activeLevel.deadEighthsOn || activeLevel.deadSixteenthsOn){
                     if([2,5].includes(beatNumber)){
                         beatNumber = "ti";
                     } else if([3,6].includes(beatNumber)){
@@ -435,14 +435,19 @@ const passageGenerator = function(blocks){
         const ticksPerDeadCount = activeLevel.tuplet ? ticksPerBeat : ticksPerBeat/2;
         const remainderDifference = Math.abs(tickRemainder-ticksPerDeadCount);
         if(activeLevel.deadEighthsOn && remainderDifference <= BEAT_TICKS_ERROR_RANGE/2){
-            return activeLevel.tuplet ? COMPOUND_COUNT_STRINGS["0.500"] : SIMPLE_COUNT_STRINGS["0.500"];
+            return SIMPLE_COUNT_STRINGS["0.500"];
         } else {
-            return "";
+            const beatDecimal = (tickRemainder / ticksPerBeat).toFixed(3);
+            return activeLevel.deadSixteenthsOn ? this.getDeadCountText(beatDecimal, activeLevel.tuplet): "";
         }
     }
 
-    this.getCompoundDeadCount = function(tickDecimal){
-        return COMPOUND_COUNT_STRING[tickDecimal.toString()]
+    this.getDeadCountText = function(beatDecimal, levelIsCompound){
+        if(levelIsCompound){
+            return COMPOUND_COUNT_STRINGS[beatDecimal];
+        } else {
+            return SIMPLE_COUNT_STRINGS[beatDecimal];
+        }
     }
 
     this.validateTies = function(ties){

--- a/assets/javascripts/levels.js
+++ b/assets/javascripts/levels.js
@@ -28,6 +28,7 @@ const Level = function(opts){
     this.subLevels = opts["subLevels"];
     this.compound = opts["compound"];
     this.deadEighthsOn = opts["deadEighthsOn"];
+    this.deadSixteenthsOn = opts["deadSixteenthsOn"];
     this.levelBlocks = [];
     this.handleClick = function(){
         changeLevel(this);

--- a/assets/javascripts/services/customRhythmService.js
+++ b/assets/javascripts/services/customRhythmService.js
@@ -115,6 +115,7 @@ function buildLevelFromEntry(entry){
         "active": (entry.gsx$active.$t === "TRUE"),
         "compound": (entry.gsx$compound.$t === "TRUE"), 
         "deadEighthsOn": (entry.gsx$thnotecounts.$t === "TRUE"),
+        "deadSixteenthsOn": (entry.gsx$thnotecounts_2.$t === "TRUE"),
         "subLevels": getSubLevelArray(entry.gsx$sublevels.$t)
     }
     const newLevel = new Level(levelAttrs)


### PR DESCRIPTION
Implements another toggle column to allow 16th note dead counts
to be displayed.

16th note dead counts will also trigger 8th note dead counts
by default, regardless of the toggle status.