### PR TITLE
Add ties to redraw function

### DIFF
--- a/assets/javascripts/components/passageGenerator.js
+++ b/assets/javascripts/components/passageGenerator.js
@@ -104,6 +104,8 @@ const passageGenerator = function(blocks){
 
         this.drawTuplets(this.tuplets2);
         this.drawTuplets(this.tuplets);
+        this.drawTies(this.ties);
+        this.drawTies(this.ties2);
         if(countsOn){
             this.voice1Counts.draw(this.np.context, this.np.stave);
             this.voice2Counts.draw(this.np.context, this.np.stave2);


### PR DESCRIPTION
This change allows ties to be redrawn when the counts are turned
on/off. Previously, when the counts were toggled, it forced a redraw of the generated passage. Without redrawing the ties, they disappeared, which is less than ideal. But that's all fixed now!