### PR TITLE
Move mix control buttons above blocks

### DIFF
--- a/index.html
+++ b/index.html
@@ -72,14 +72,13 @@
           <canvas id="target">
           </canvas>
         </div>
-        <div id="blocks-select-container" class="container">
-        </div>
-
         <div id="inputs" class="container">
           <button onclick="generate()">New Mix</button>
           <button class="dark" onclick="deselectAll()">Deselect All</button>
           <button class="dark" onclick="selectAll()">Select All</button>
           <button class="dark" onclick="toggleShareSettings()">Share Settings</button>
+        </div>
+        <div id="blocks-select-container" class="container">
         </div>
       </div>
     </div>


### PR DESCRIPTION
This should make the UI easier to read and use
on smaller screens and for presentation
configurations/modes.